### PR TITLE
simplification

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 // Public intefrace
 module.exports = promisedPipe
 
-const ensureFunctionType = (fn, i) => {
-    if (typeof fn !== 'function') {
-        throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fn}"`)
-    }
-}
-
 const chain = (q, fn) => q.then(fn)
 
 function promisedPipe(...fns) {
@@ -14,10 +8,21 @@ function promisedPipe(...fns) {
         throw Error('pipe requires at least one argument')
     }
 
-    fns.forEach(ensureFunctionType)
+    let i = -1
+    while (++i < fns.length) {
+        if (typeof fns[i] !== 'function') {
+            throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fns[i]}"`)
+        }
+    }
 
     // shift out the 1st function for multiple arguments
     const start = fns.shift()
 
-    return (...args) => fns.reduce(chain, Promise.resolve(start(...args)))
+    return (...args) => {
+        try {
+            return fns.reduce(chain, Promise.resolve(start(...args)))
+        } catch (err) {
+            return Promise.reject(err)
+        }
+    }
 }

--- a/index.js
+++ b/index.js
@@ -1,35 +1,23 @@
 // Public intefrace
 module.exports = promisedPipe
 
+const ensureFunctionType = (fn, i) => {
+    if (typeof fn !== 'function') {
+        throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fn}"`)
+    }
+}
+
+const chain = (q, fn) => q.then(fn)
+
 function promisedPipe(...fns) {
     if (fns.length < 1) {
         throw Error('pipe requires at least one argument')
     }
 
-    fns.forEach((fn, i) => {
-        if (typeof fn !== 'function') {
-            throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fn}"`)
-        }
-    })
+    fns.forEach(ensureFunctionType)
 
-    /*
-     * Does the same as q.promised
-     * https://github.com/kriskowal/q/wiki/API-Reference#qpromisedfunc
-     *
-     * Creates a new version of func that accepts any combination of promise and non-promise
-     * values, converting them to their fulfillment values before calling the original func.
-     * The returned version also always returns a promise: if func does a return or throw,
-     * then Q.promised(func) will return fulfilled or rejected promise, respectively.
-     *
-     */
-    const promised = fn => (...args) => Promise.all(args).then(_args => fn.apply(null, _args))
+    // shift out the 1st function for multiple arguments
+    const start = fns.shift()
 
-    /*
-     * Does the same as Ramda.pipe
-     * http://ramdajs.com/docs/#pipe
-     *
-     * Performs left-to-right function composition. The leftmost function may have any arity;
-     * the remaining functions must be unary.
-     */
-    return (...args) => fns.map(promised).reduce((acc, cur) => [cur.apply(null, acc)], args)[0]
+    return (...args) => fns.reduce(chain, Promise.resolve(start(...args)))
 }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,11 @@ function promisedPipe(...fns) {
         throw Error('pipe requires at least one argument')
     }
 
-    let i = -1
-    while (++i < fns.length) {
-        if (typeof fns[i] !== 'function') {
-            throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fns[i]}"`)
-        }
-    }
+    fns.forEach((fn, i) => {
+        if (typeof fn !== 'function') {
+            throw Error(`pipe requires each argument to be a function. Argument #${i+1} is of type "${typeof fn}"`)
+        }        
+    })
 
     // shift out the 1st function for multiple arguments
     const start = fns.shift()

--- a/index.js
+++ b/index.js
@@ -18,11 +18,5 @@ function promisedPipe(...fns) {
     // shift out the 1st function for multiple arguments
     const start = fns.shift()
 
-    return (...args) => {
-        try {
-            return fns.reduce(chain, Promise.resolve(start(...args)))
-        } catch (err) {
-            return Promise.reject(err)
-        }
-    }
+    return (...args) => fns.reduce(chain, new Promise(res => res(start(...args))))
 }


### PR DESCRIPTION
A lot of the logic isn't necessary since promise only return a single argument.

So instead of wrapping each function in an async spread  we can simply do the spread for the first
and use the fact that the chain will only pass a single argument.

and then we chain the rest of the functions using `Promise.resolve()` to ensure we start with a promise

Also I hoisted out some functions to explicitly use them by name instead of re-creating them at each execution.

All tests pass.